### PR TITLE
fix: overflow fixed for header in home page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,19 +81,17 @@
   box-sizing: border-box;
   padding: 0;
   margin: 0;
-  overflow-x: hidden;
-  overflow-y: visible;
+  font-family: inherit;
 }
 
 html,
 body {
   max-width: 100vw;
   font-family: "Alexandria", sans-serif;
+  overflow-x: hidden;
+  overflow-y: visible;
 }
 
-* {
-  font-family: inherit;
-}
 body {
   color: rgb(var(--foreground-rgb));
   background: #faf1f5;


### PR DESCRIPTION
## Changes Made:

Previously, the overflow was set to "*", which was causing the header to exhibit unexpected behavior.
In this PR, the overflow property has been adjusted to "body,html" to resolve the issue.

## Related Issues

Fixes #68 

Please review and merge this PR. Thank you!